### PR TITLE
Support for legacy Creation Kit Wiki links

### DIFF
--- a/rule_wiki.json
+++ b/rule_wiki.json
@@ -8,7 +8,7 @@
         }
     },
     "condition": {
-        "regexFilter": "^https?:\\/\\/(?:www\\.)?creationkit.com\\/index.php\\?title=((?:[\\w:()]|%[0-9a-fA-F]{2})+)$",
+        "regexFilter": "^https?:\\/\\/(?:www\\.)?creationkit.com\\/(?:index.php\\?title=)?((?:[\\w:()]|%[0-9a-fA-F]{2})+)$",
         "resourceTypes": ["main_frame", "sub_frame"]
     }
 }]


### PR DESCRIPTION
I forgot that the CK Wiki at one point operated without the use of "index.php?title="
Modern links have it, but older links do not. For an example, see [an archived version of the Editor Reference page](https://web.archive.org/web/20140816144149/http://www.creationkit.com/Category:Editor_Reference)