### PR TITLE
Support Fallout URLs & Hyphens

### DIFF
--- a/rule_wiki.json
+++ b/rule_wiki.json
@@ -4,11 +4,11 @@
     "action": {
         "type": "redirect",
         "redirect": {
-            "regexSubstitution": "https://ck.uesp.net/wiki/\\1"
+            "regexSubstitution": "https://\\1ck.uesp.net/wiki/\\2"
         }
     },
     "condition": {
-        "regexFilter": "^https?:\\/\\/(?:www\\.)?creationkit.com\\/(?:index.php\\?title=)?((?:[\\w:()]|%[0-9a-fA-F]{2})+)$",
+        "regexFilter": "^https?:\\/\\/(?:www\\.)?creationkit.com\\/(?:(fallout)4\\/)?(?:index.php\\?title=)?((?:[\\w:()]|%[0-9a-fA-F]{2})+)$",
         "resourceTypes": ["main_frame", "sub_frame"]
     }
 }]

--- a/rule_wiki.json
+++ b/rule_wiki.json
@@ -8,7 +8,7 @@
         }
     },
     "condition": {
-        "regexFilter": "^https?:\\/\\/(?:www\\.)?creationkit.com\\/(?:(fallout)4\\/)?(?:index.php\\?title=)?((?:[\\w:()]|%[0-9a-fA-F]{2})+)$",
+        "regexFilter": "^https?:\\/\\/(?:www\\.)?creationkit.com\\/(?:(fallout)4\\/)?(?:index.php\\?title=)?((?:[\\w\\-:()]|%[0-9a-fA-F]{2})+)$",
         "resourceTypes": ["main_frame", "sub_frame"]
     }
 }]


### PR DESCRIPTION
Specific support for the Fallout URLs in the wiki (`creationkit.com/fallout4/index.php`) and support for hyphens in page titles.